### PR TITLE
added option to change output file name

### DIFF
--- a/lib/chef/knife/supermarket_download.rb
+++ b/lib/chef/knife/supermarket_download.rb
@@ -31,7 +31,12 @@ class Chef
         :description => 'Supermarket Site',
         :default => 'https://supermarket.chef.io',
         :proc => Proc.new { |supermarket| Chef::Config[:knife][:supermarket_site] = supermarket }
-
+      
+      option :file,
+        :short => '-f FILE',
+        :long => '--file FILE',
+        :description => 'The filename to write to.'
+	
       def cookbooks_api_url
         "#{config[:supermarket_site]}/api/v1/cookbooks"
       end

--- a/lib/knife-supermarket/version.rb
+++ b/lib/knife-supermarket/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Supermarket
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
Currently we don't allow to pass a -f flag to change the filename of a downloaded cookbook.

Upstream in the delivery-cli I am putting in a PR that will leverage knife-supermarket instead of knife-cookbook-site download to get build cookbooks so as to allow users to pull build cookbooks from private supermarkets. To avoid extensive rewrites we really need to be able to pass this option.

